### PR TITLE
Fix includes for GCC 7

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -27,6 +27,7 @@
 #include <future>
 #include <set>
 #include <unordered_map>
+#include <functional>
 
 #define SDL_MAIN_HANDLED
 #include <SDL.h>

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 #include <array>
 #include <limits.h>
+#include <functional>
 
 #include <SDL.h>
 

--- a/src/gpuvis_utils.cpp
+++ b/src/gpuvis_utils.cpp
@@ -30,6 +30,7 @@
 #include <cctype>
 #include <sstream>
 #include <unordered_map>
+#include <functional>
 
 #include <SDL.h>
 


### PR DESCRIPTION
The <functional> include is no longer implicitly included by other includes, hence it needs to be explicitly included where it is being used.

Fixes #5 