### PR TITLE
Open files in binary mode on Windows.

### DIFF
--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1431,7 +1431,11 @@ static tracecmd_input_t *tracecmd_alloc( const char *file )
 {
     int fd;
 
+#if defined( WIN32 )
+    fd = TEMP_FAILURE_RETRY( open( file, O_RDONLY | O_BINARY ) );
+#else
     fd = TEMP_FAILURE_RETRY( open( file, O_RDONLY ) );
+#endif
     if ( fd < 0 )
     {
         logf( "%s: open(\"%s\") failed: %d\n", __func__, file, errno );


### PR DESCRIPTION
This fixes an issue whereby a trace file containing equivalent of CTRL-Z char will cause GPUVis to crash as Windows will consider the file to be at EOF