### PR TITLE
gpuvis_trace_utils: Add 'static' to gpuvis_gettime_u64

### DIFF
--- a/sample/gpuvis_trace_utils.h
+++ b/sample/gpuvis_trace_utils.h
@@ -101,7 +101,7 @@ GPUVIS_EXTERN const char *gpuvis_get_tracefs_filename( char *buf, size_t buflen,
 // Internal function used by GPUVIS_COUNT_HOT_FUNC_CALLS macro
 GPUVIS_EXTERN void gpuvis_count_hot_func_calls_internal_( const char *func );
 
-inline uint64_t gpuvis_gettime_u64( void )
+static inline uint64_t gpuvis_gettime_u64( void )
 {
     struct timespec ts;
 


### PR DESCRIPTION
Fixes linker error

"undefined reference to `gpuvis_gettime_u64'"