### PR TITLE
fix compilation on non-windows

### DIFF
--- a/src/gpuvis_etl.cpp
+++ b/src/gpuvis_etl.cpp
@@ -997,7 +997,7 @@ int read_etl_file( const char *file, StrPool &strpool, trace_info_t &trace_info,
 // Stub implementation for non-windows OSs
 int read_etl_file( const char *file, StrPool &strpool, trace_info_t &trace_info, EventCallback &cb )
 {
-    return -1
+    return -1;
 }
 #endif
 


### PR DESCRIPTION
A better fix would be to not compile the file in the first place, but let's start with valid C++ code for now