### PR TITLE
Trace block macro c

### DIFF
--- a/sample/glxgears.c
+++ b/sample/glxgears.c
@@ -151,6 +151,9 @@ gear( GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
     GLfloat angle, da;
     GLfloat u, v, len;
 
+    GPUVIS_TRACE_BLOCKF( "build gear inner=%.2f, outer=%.2f, width=%.2f",
+            inner_radius, outer_radius, width );
+
     r0 = inner_radius;
     r1 = outer_radius - tooth_depth / 2.0;
     r2 = outer_radius + tooth_depth / 2.0;
@@ -280,6 +283,7 @@ gear( GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
 static void
 draw( void )
 {
+    GPUVIS_TRACE_BLOCK( "draw" );
     glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
     glPushMatrix();


### PR DESCRIPTION
This PR ports the `GPUVIS_TRACE_BLOCK(F)` to C, with the help of some GNU extensions. I am using this in our project (which is mostly C), thought it might be useful to others. You can find details in the commit messages.

I tested this on Linux with C and C++, GCC 8 and Clang 8, also with `GPUVIS_TRACE_UTILS_DISABLE=1`. Looking forward to your feedback!