### PR TITLE
Integrate i915-perf data into GPUvis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 project( "gpuvis" )
 
 option(USE_FREETYPE "USE_FREETYPE" ON)
+option(USE_I915_PERF "USE_I915_PERF" OFF)
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
@@ -81,6 +82,12 @@ elseif ( UNIX AND NOT APPLE )
     LINK_LIBRARIES( dl )
 endif()
 
+if ( USE_I915_PERF )
+    pkg_check_modules( I915_PERF REQUIRED i915-perf )
+    ucm_add_flags( -DUSE_I915_PERF )
+endif()
+
+
 ucm_print_flags()
 
 # Main source list
@@ -91,6 +98,7 @@ set ( SRC_LIST
     src/gpuvis_plots.cpp
     src/gpuvis_graphrows.cpp
     src/gpuvis_ftrace_print.cpp
+    src/gpuvis_i915_perfcounters.cpp
     src/gpuvis_utils.cpp
 	src/gpuvis_etl.cpp
 	src/etl_utils.cpp
@@ -105,6 +113,7 @@ set ( SRC_LIST
     src/imgui/imgui_draw.cpp
     src/imgui/imgui_freetype.cpp
     src/GL/gl3w.c
+    src/i915-perf/i915-perf-read.cpp
     src/trace-cmd/event-parse.c
     src/trace-cmd/trace-seq.c
     src/trace-cmd/kbuffer-parse.c
@@ -120,6 +129,7 @@ include_directories(
     ${FREETYPE_INCLUDE_DIRS}
     ${GTK3_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
+    ${I915_PERF_INCLUDE_DIRS}
     )
 
 ucm_add_target( NAME gpuvis TYPE EXECUTABLE SOURCES ${SRC_LIST} )
@@ -130,4 +140,5 @@ target_link_libraries(
     ${SDL2_LIBRARY}
     ${FREETYPE_LIBRARIES}
     ${GTK3_LIBRARIES}
+    ${I915_PERF_LIBRARIES}
     )

--- a/sample/trace-cmd-capture.sh
+++ b/sample/trace-cmd-capture.sh
@@ -19,6 +19,11 @@ CMD="trace-cmd stop"
 echo ${CMD}
 $CMD
 
+# Extract i915-perf trace
+CMD="i915-perf-control -d trace_${DATE}.i915-dat"
+echo ${CMD}
+$CMD
+
 # Extract trace
 CMD="trace-cmd extract -k -o trace_${DATE}.dat"
 echo ${CMD}

--- a/sample/trace-cmd-command.sh
+++ b/sample/trace-cmd-command.sh
@@ -86,7 +86,7 @@ DATE=$(date +%m-%d-%Y_%H-%M-%S)
 TRACEFILE=trace_${DATE}.dat
 
 echo
-CMD="trace-cmd record -b 8000 -D -o ${TRACEFILE} -i ${EVENTS} ${COMMAND}"
+CMD="trace-cmd record -C mono -b 8000 -D -o ${TRACEFILE} -i ${EVENTS} ${COMMAND}"
 echo $CMD
 $CMD
 

--- a/sample/trace-cmd-setup.sh
+++ b/sample/trace-cmd-setup.sh
@@ -83,6 +83,9 @@ else
     ROOT_CMDS+="chmod 0222 \"${TRACEFS}/trace_marker\"\n"
 fi
 
+# Enable i915-perf to collect GPU data.
+ROOT_CMDS+="sysctl dev.i915.perf_stream_paranoid=0"
+
 if [ -z "${ROOT_CMDS}" ]; then
     :
 else
@@ -134,4 +137,3 @@ else
 fi
 
 spewTraceStatus
-

--- a/sample/trace-cmd-start-tracing.sh
+++ b/sample/trace-cmd-start-tracing.sh
@@ -64,7 +64,7 @@ echo $CMD
 $CMD
 
 echo
-CMD="trace-cmd start -b 8000 -D -i ${EVENTS}"
+CMD="trace-cmd start -C mono -b 8000 -D -i ${EVENTS}"
 echo $CMD
 $CMD
 

--- a/sample/trace-cmd-stop-tracing.sh
+++ b/sample/trace-cmd-stop-tracing.sh
@@ -8,4 +8,10 @@ CMD="trace-cmd snapshot -f"
 echo $CMD
 $CMD
 
+if [ "${USE_I915_PERF} " ]; then
+    CMD="i915-perf-control -q"
+    echo $CMD
+    $CMD
+fi
+
 ./trace-cmd-status.sh

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -713,6 +713,9 @@ int TraceEvents::new_event_cb( const trace_event_t &event )
     // Add event to our m_events array
     m_events.push_back( event );
 
+    // Assign an event id
+    m_events.back().id = m_events.size() - 1;
+
     // If this is a sched_switch event, see if it has comm info we don't know about.
     // This is the reason we're initializing events in two passes to collect all this data.
     if ( event.is_sched_switch() )

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -1055,7 +1055,7 @@ public:
     void init( int argc, char **argv );
     void shutdown( SDL_Window *window );
 
-    bool load_file( const char *filename );
+    bool load_file( const char *filename, bool last );
     void cancel_load_file();
 
     // Trace file loaded and viewing?
@@ -1119,6 +1119,8 @@ public:
         TraceWin *win = nullptr;
         SDL_Thread *thread = nullptr;
         std::vector< std::string > inputfiles;
+
+        bool last;
     };
     loading_info_t m_loading_info;
 

--- a/src/gpuvis_colors.inl
+++ b/src/gpuvis_colors.inl
@@ -68,6 +68,7 @@ _XTAG( col_Graph_TaskRunning, 0x4fff00ff, "Sched_switch task running block" )
 _XTAG( col_Graph_TaskSleeping, 0x4fffff00, "Sched_switch task sleeping block" )
 
 _XTAG( col_Graph_Bari915ReqWait, 0x4f0000ff, "i915 reqwait bar" )
+_XTAG( col_Graph_i915Perf, 0xff9b9400, "i915-perf bar" )
 
 _XTAG( col_Graph_Bari915Queue, 0xc81d740c, "Request queued waiting to be added" )
 _XTAG( col_Graph_Bari915SubmitDelay, 0xc8f8552e, "Requests waiting on fences and dependencies before they are runnable" )

--- a/src/gpuvis_etl.cpp
+++ b/src/gpuvis_etl.cpp
@@ -628,7 +628,6 @@ public:
         , mTraceInfo( trace_info )
         , mCallback( cb )
         , mReader( file,  process_event_cb_proxy, this )
-        , mCurrentEventId( 0 )
         , mStartTicks( 0 )
         , mAdapterCount( 0 )
         , mCrtcCount( 0 )
@@ -717,7 +716,6 @@ private:
     EventCallback &mCallback;
 
     etl_reader_t mReader;
-    uint32_t mCurrentEventId;
     uint64_t mStartTicks;
 
     std::unordered_map<uint64_t, int> mAdapterMap;
@@ -827,7 +825,6 @@ private:
         }
 
         event.pid = entry.tid;
-        event.id = mCurrentEventId++;
         event.cpu = entry.cpu;
         event.ts = ticks_to_relative_us( entry.ts );
         event.comm = comm;

--- a/src/gpuvis_ftrace_print.cpp
+++ b/src/gpuvis_ftrace_print.cpp
@@ -295,7 +295,7 @@ void TraceEvents::new_event_ftrace_print( trace_event_t &event )
 
     if ( bufvar == bufvar_ltime )
     {
-        event.ts = atoll( var_ltime ) - m_trace_info.min_file_ts;
+        event.ts = atoll( var_ltime );
 
         // Remove "ltime=XXX", etc from buf
         buf = trim_ftrace_print_buf( newbuf, buf, var_ltime, s_buf_vars[ bufvar ].len );

--- a/src/gpuvis_graphrows.cpp
+++ b/src/gpuvis_graphrows.cpp
@@ -310,6 +310,8 @@ void GraphRows::init( TraceEvents &trace_events )
 
     // Intel gpu events
     {
+        push_row( "i915-perf", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+
         for ( auto &req_locs : trace_events.m_i915.req_locs.m_locs.m_map )
         {
             std::vector< uint32_t > &locs = req_locs.second;

--- a/src/gpuvis_i915_perfcounters.cpp
+++ b/src/gpuvis_i915_perfcounters.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <functional>
+#include <string>
+
+#include <SDL.h>
+
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"   // BeginColumns(), EndColumns(), PushColumnClipRect()
+
+#include "gpuvis_macros.h"
+#include "stlini.h"
+#include "trace-cmd/trace-read.h"
+#include "gpuvis_utils.h"
+#include "gpuvis.h"
+
+#ifdef USE_I915_PERF
+
+#include <perf.h>
+#include <perf_data_reader.h>
+
+static void
+pretty_print_value(intel_perf_logical_counter_unit_t unit,
+                   double value,
+                   char *buffer, size_t length)
+{
+    static const char *times[] = { "ns", "us", "ms", "s" };
+    static const char *bytes[] = { "B", "KiB", "MiB", "GiB" };
+    static const char *freqs[] = { "Hz", "KHz", "MHz", "GHz" };
+    static const char *texels[] = { "texels", "K texels", "M texels", "G texels" };
+    static const char *pixels[] = { "pixels", "K pixels", "M pixels", "G pixels" };
+    static const char *cycles[] = { "cycles", "K cycles", "M cycles", "G cycles" };
+    static const char *threads[] = { "threads", "K threads", "M threads", "G threads" };
+    const char **scales = NULL;
+
+    switch (unit) {
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_BYTES:   scales = bytes; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_HZ:      scales = freqs; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_NS:
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_US:      scales = times; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_PIXELS:  scales = pixels; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_TEXELS:  scales = texels; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_THREADS: scales = threads; break;
+    case INTEL_PERF_LOGICAL_COUNTER_UNIT_CYCLES:  scales = cycles; break;
+    default: break;
+    }
+
+    if (scales) {
+        const double base = unit == INTEL_PERF_LOGICAL_COUNTER_UNIT_BYTES ? 1024 : 1000;
+
+        if (unit == INTEL_PERF_LOGICAL_COUNTER_UNIT_US)
+            value *= 1000;
+
+        int i = 0;
+        while (value >= base && i < 3) {
+            value /= base;
+            i++;
+        }
+        snprintf(buffer, length, "%.4g %s", value, scales ? scales[i] : "");
+    } else {
+        if (unit == INTEL_PERF_LOGICAL_COUNTER_UNIT_PERCENT)
+            snprintf(buffer, length, "%.3g %%", value);
+        else
+            snprintf(buffer, length, "%.2f", value);
+    }
+}
+
+void I915PerfCounters::init( TraceEvents &trace_events )
+{
+    m_trace_events = &trace_events;
+
+    m_counters.clear();
+
+    const struct intel_perf_metric_set *metric_set =
+        m_trace_events->i915_perf_reader->metric_set;
+
+    for ( uint32_t c = 0; c < metric_set->n_counters; c++ )
+    {
+        struct intel_perf_logical_counter *counter = &metric_set->counters[c];
+
+        i915_perf_counter_t dcounter;
+
+        dcounter.name = std::string(counter->name);
+        dcounter.desc = std::string(counter->desc);
+        dcounter.type =
+            (counter->storage == INTEL_PERF_LOGICAL_COUNTER_STORAGE_FLOAT ||
+             counter->storage == INTEL_PERF_LOGICAL_COUNTER_STORAGE_DOUBLE) ?
+            i915_perf_counter_t::type::FLOAT :
+            i915_perf_counter_t::type::INTEGER;
+
+        m_counters.push_back(dcounter);
+    }
+}
+
+void I915PerfCounters::set_event( const trace_event_t &event )
+{
+    if ( m_event_id == event.id || event.id == INVALID_ID )
+        return;
+
+    m_event_id = event.id;
+
+    assert( event.i915_perf_timeline != INVALID_ID );
+
+    const struct intel_perf_metric_set *metric_set =
+        m_trace_events->i915_perf_reader->metric_set;
+    const struct intel_perf_timeline_item *timeline_item =
+        &m_trace_events->i915_perf_reader->timelines[event.i915_perf_timeline];
+    const struct drm_i915_perf_record_header *record_start =
+        m_trace_events->i915_perf_reader->records[timeline_item->record_start];
+    const struct drm_i915_perf_record_header *record_end =
+        m_trace_events->i915_perf_reader->records[timeline_item->record_end];
+
+    struct intel_perf_accumulator accu;
+    intel_perf_accumulate_reports( &accu, metric_set->perf_oa_format,
+                                   record_start, record_end );
+
+    m_n_reports = timeline_item->record_end - timeline_item->record_start;
+
+    for ( uint32_t c = 0; c < metric_set->n_counters; c++ )
+    {
+        struct intel_perf_logical_counter *counter = &metric_set->counters[c];
+        struct i915_perf_counter_t &dcounter = m_counters[c];
+
+        if ( m_counters[c].type == i915_perf_counter_t::type::FLOAT )
+        {
+            dcounter.value.f = counter->read_float( m_trace_events->i915_perf_reader->perf,
+                                                    metric_set, accu.deltas );
+            if ( counter->max_float )
+            {
+                dcounter.max_value.f = counter->max_float( m_trace_events->i915_perf_reader->perf,
+                                                           metric_set, accu.deltas );
+            }
+            else
+            {
+                dcounter.max_value.f = 0.0f;
+            }
+            pretty_print_value( counter->unit, dcounter.value.f,
+                                dcounter.pretty_value, sizeof(dcounter.pretty_value) );
+        }
+        else
+        {
+            dcounter.value.u = counter->read_uint64( m_trace_events->i915_perf_reader->perf,
+                                                     metric_set, accu.deltas );
+            if ( counter->max_uint64 )
+            {
+                dcounter.max_value.u = counter->max_uint64( m_trace_events->i915_perf_reader->perf,
+                                                            metric_set, accu.deltas );
+            }
+            else
+            {
+                dcounter.max_value.u = 0;
+            }
+            pretty_print_value( counter->unit, dcounter.value.u,
+                                dcounter.pretty_value, sizeof(dcounter.pretty_value) );
+        }
+    }
+}
+
+I915PerfCounters::i915_perf_process
+I915PerfCounters::get_process( const trace_event_t &i915_perf_event )
+{
+    i915_perf_process process;
+    process.label = "<unknown>";
+    process.color = s_clrs().get( col_Graph_i915Perf );
+
+    uint32_t *req_event_id = m_trace_events->m_i915.perf_to_req_in.get_val( i915_perf_event.id );
+
+    if ( req_event_id )
+    {
+        const trace_event_t &req_event = m_trace_events->m_events[ *req_event_id ];
+        process.label = req_event.comm;
+
+        const std::vector< uint32_t > *sched_plocs =
+            m_trace_events->get_sched_switch_locs( req_event.pid,
+                                                   TraceEvents::SCHED_SWITCH_PREV );
+        if ( sched_plocs )
+        {
+            const trace_event_t &e = m_trace_events->m_events[ sched_plocs->back() ];
+            process.color = e.color;
+        }
+    }
+
+    return process;
+}
+
+void I915PerfCounters::render()
+{
+    if ( m_event_id == INVALID_ID )
+        return;
+
+    m_filter.Draw();
+    ImGui::SameLine();
+
+    i915_perf_process process = get_process( m_trace_events->m_events[ m_event_id ] );
+    ImGui::Text( "Process: %s", process.label );
+    ImGui::SameLine();
+    ImGui::ColorButton( "##process_color", ImColor( process.color ),
+                        ImGuiColorEditFlags_NoInputs |
+                        ImGuiColorEditFlags_NoTooltip |
+                        ImGuiColorEditFlags_NoLabel );
+    ImGui::SameLine();
+    ImGui::Text( "Reports: %u", m_n_reports );
+
+    const ImVec2 content_avail = ImGui::GetContentRegionAvail();
+    ImGui::BeginChild( "i915-counters-listbox", ImVec2( 0.0f, content_avail.y ) );
+
+    if ( imgui_begin_columns( "i915_counters", { "Percent", "Name", "Value", "Description" } ) )
+        ImGui::SetColumnWidth( 0, imgui_scale( 250.0f ) );
+
+    float lineh = ImGui::GetTextLineHeightWithSpacing() - 4;
+    for ( const i915_perf_counter_t &c : m_counters )
+    {
+        const i915_perf_count_value_t &c_val = c.value;
+        const i915_perf_count_value_t &c_max_val = c.max_value;
+
+        if ( !m_filter.PassFilter( c.name.c_str() ) )
+            continue;
+
+        if ( c.type == i915_perf_counter_t::type::INTEGER )
+        {
+            ImGui::ProgressBar( c_max_val.u == 0 ? 0 : ((double) c_val.u / c_max_val.u), ImVec2(-1, lineh) );
+        }
+        else
+        {
+            ImGui::ProgressBar( c_max_val.f == 0.f ? 0.f : c_val.f / c_max_val.f, ImVec2(-1, lineh) );
+        }
+        ImGui::NextColumn();
+        ImGui::Text( "%s", c.name.c_str() );
+        ImGui::NextColumn();
+        if ( c.type == i915_perf_counter_t::type::INTEGER )
+        {
+            ImGui::Text( "%lu -- %s", c_val.u, c.pretty_value );
+        }
+        else
+        {
+            ImGui::Text( "%f -- %s", c_val.f, c.pretty_value );
+        }
+        ImGui::NextColumn();
+        ImGui::Text( "%s", c.desc.c_str() );
+        ImGui::NextColumn();
+    }
+
+    ImGui::EndColumns();
+
+    ImGui::EndChild();
+}
+
+#else
+
+void I915PerfCounters::init( TraceEvents &trace_events )
+{
+}
+
+void I915PerfCounters::set_event( const trace_event_t &event )
+{
+}
+
+I915PerfCounters::i915_perf_process
+I915PerfCounters::get_process( const trace_event_t &i915_perf_event )
+{
+    i915_perf_process ret;
+
+    return ret;
+}
+
+void I915PerfCounters::render()
+{
+}
+
+#endif

--- a/src/i915-perf/i915-perf-read.cpp
+++ b/src/i915-perf/i915-perf-read.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif
+
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string>
+#include <vector>
+#include <forward_list>
+#include <csetjmp>
+#include <unordered_map>
+#include <unordered_set>
+#include <algorithm>
+#include <future>
+#include <string.h>
+
+#ifdef USE_I915_PERF
+#include <perf.h>
+#include <perf_data_reader.h>
+#endif
+
+#include "gpuvis_macros.h"
+#include "trace-cmd/trace-read.h"
+#include "i915-perf-read.h"
+
+void logf( const char *fmt, ... ) ATTRIBUTE_PRINTF( 1, 2 );
+
+int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace_info, struct intel_perf_data_reader **out_reader, EventCallback &cb )
+{
+    GPUVIS_TRACE_BLOCK( __func__ );
+
+#ifdef USE_I915_PERF
+    int fd = open( file, O_RDONLY );
+    if ( fd < 0 )
+    {
+        logf( "[Error] %s: opening i915-perf file failed: %s.\n", __func__, strerror( errno ) );
+        return -1;
+    }
+
+    *out_reader = new intel_perf_data_reader;
+    struct intel_perf_data_reader *reader = *out_reader;
+
+    if ( !intel_perf_data_reader_init( reader, fd ) )
+    {
+        logf( "[Error] %s: initializing i915-perf reader failed: %s.\n", __func__, reader->error_msg );
+        return -1;
+    }
+
+    trace_info.file = std::string(file);
+
+    for (uint32_t i = 0; i < reader->n_timelines; i++)
+    {
+        if ( reader->timelines[i].hw_id == 0xffffffff )
+            continue;
+
+        trace_event_t event;
+
+        if ( reader->timelines[i].cpu_ts_start < trace_info.min_file_ts )
+            continue;
+
+        // Abuse PID, this is kind of a similar concept...
+        event.flags = TRACE_FLAG_I915_PERF;
+        event.pid = reader->timelines[i].hw_id;
+        event.cpu = 0;
+        event.comm = strpool.getstr( "i915-perf" );
+        event.system = strpool.getstr( "i915-perf" );
+        event.user_comm = strpool.getstrf( "[i915-perf hw_id=0x%x]", reader->timelines[i].hw_id );
+
+        event.name = strpool.getstr( "i915-perf-begin" );
+        event.ts = reader->timelines[i].cpu_ts_start;
+        event.duration = reader->timelines[i].cpu_ts_end - reader->timelines[i].cpu_ts_start;
+
+        // This will track the timeline number and allow us to compute counter
+        // deltas.
+        event.i915_perf_timeline = i;
+
+        cb( event );
+
+        event.name = strpool.getstr( "i915-perf-end" );
+        // The GPU context switch event happens on a single timestamp. Make
+        // begin/end look like they happen at different time so that events
+        // are ordered properly.
+        event.ts = reader->timelines[i].cpu_ts_end - 1;
+        event.duration = INT64_MAX;
+
+        cb( event );
+    }
+#endif
+
+    return 0;
+}

--- a/src/i915-perf/i915-perf-read.h
+++ b/src/i915-perf/i915-perf-read.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef I915_PERF_READ_H_
+#define I915_PERF_READ_H_
+
+struct intel_perf_data_reader;
+
+int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace_info, struct intel_perf_data_reader **reader, EventCallback &cb );
+
+#endif // I915_PERF_READ_H_

--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1648,7 +1648,7 @@ static int trace_enum_events( trace_data_t &trace_data, tracecmd_input_t *handle
 
         trace_event.pid = pid;
         trace_event.cpu = record->cpu;
-        trace_event.ts = record->ts - trace_data.trace_info.min_file_ts;
+        trace_event.ts = record->ts;
 
         trace_event.comm = strpool.getstrf( "%s-%u", comm, pid );
 

--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1584,7 +1584,6 @@ public:
     trace_info_t &trace_info;
     StrPool &strpool;
 
-    uint32_t events = 0;
     const char *seqno_str;
     const char *crtc_str;
     const char *ip_str;
@@ -1648,7 +1647,6 @@ static int trace_enum_events( trace_data_t &trace_data, tracecmd_input_t *handle
         trace_seq_init( &seq );
 
         trace_event.pid = pid;
-        trace_event.id = trace_data.events++;
         trace_event.cpu = record->cpu;
         trace_event.ts = record->ts - trace_data.trace_info.min_file_ts;
 

--- a/src/trace-cmd/trace-read.h
+++ b/src/trace-cmd/trace-read.h
@@ -171,6 +171,7 @@ enum trace_flag_type_t {
     TRACE_FLAG_SCHED_SWITCH_TASK_RUNNING    = 0x08000, // TASK_RUNNING
     TRACE_FLAG_SCHED_SWITCH_SYSTEM_EVENT    = 0x10000,
     TRACE_FLAG_AUTOGEN_COLOR                = 0x20000,
+    TRACE_FLAG_I915_PERF                    = 0x40000, // i915-perf gpu generated
 };
 
 struct trace_event_t
@@ -190,6 +191,8 @@ public:
     int crtc = -1;                    // drm_vblank_event crtc (or -1)
     int64_t vblank_ts = INT64_MAX;    // time-stamp that is passed with the drm_event_vblank event
     bool vblank_ts_high_prec = false; // denotes whether or not the hardware timestamp is high-precision
+    uint32_t i915_perf_timeline =
+        INVALID_ID;                   // Pointer into the i915-perf timelines to this element.
 
     uint32_t color = 0;             // color of the event (or 0 for default)
 
@@ -214,6 +217,7 @@ public:
     bool is_vblank() const                     { return !!( flags & TRACE_FLAG_VBLANK ); }
     bool is_timeline() const                   { return !!( flags & TRACE_FLAG_TIMELINE ); }
     bool is_sched_switch() const               { return !!( flags & TRACE_FLAG_SCHED_SWITCH ); }
+    bool is_i915_perf() const                  { return !!( flags & TRACE_FLAG_I915_PERF ); }
 
     bool has_duration() const                  { return duration != INT64_MAX; }
     int64_t get_vblank_ts(bool want_high_prec) const { return want_high_prec && (vblank_ts != INT64_MAX) && vblank_ts_high_prec ? vblank_ts : ts; }


### PR DESCRIPTION
This PR is making use of the small optional library & recording tool coming off IGT (https://gitlab.freedesktop.org/drm/igt-gpu-tools) and helps showing some data generated by Intel's Gen observation architecture.

This adds essentially 2 new things : 
   * a new row tracking the GPU utilization
   * a panel showing the details about a given GPU timeline item

It's a first stab at showing that data into GPUVis. A lot more could be added but we have to start somewhere :)

I've tried to make this optional code so that there is no hard requirement on IGT.

It works with this IGT branch : https://github.com/djdeath/intel-gpu-tools/tree/review/i915-perf-tools
Just posted for review.

A couple of screenshots :
![Screenshot from 2020-02-17 11-12-38](https://user-images.githubusercontent.com/434333/74662281-4d339780-51a2-11ea-95af-9520697b9917.png)
![Screenshot from 2020-02-17 11-16-11](https://user-images.githubusercontent.com/434333/74662284-4efd5b00-51a2-11ea-9479-f28c658ce839.png)
