### PR TITLE
Add support for importing generic DRM sched timing events.

### DIFF
--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -459,6 +459,7 @@ public:
     void init_sched_process_fork( trace_event_t &event );
     void init_amd_timeline_event( trace_event_t &event );
     void init_msm_timeline_event( trace_event_t &event );
+    void init_drm_sched_timeline_event( trace_event_t &event );
     void init_i915_event( trace_event_t &event );
     void init_i915_perf_event( trace_event_t &event );
 
@@ -597,6 +598,14 @@ public:
     SDL_atomic_t m_eventsloaded = { 1 };
 
     struct intel_perf_data_reader *i915_perf_reader = NULL;
+
+    struct {
+        // set of rings discovered during event parsing
+        std::unordered_set< std::string > rings;
+
+        // mapping from fence to outstanding job id
+        std::map<uint32_t, uint32_t> outstanding_jobs;
+    } m_drm_sched;
 };
 
 class GraphRows

--- a/src/gpuvis_graphrows.cpp
+++ b/src/gpuvis_graphrows.cpp
@@ -345,6 +345,20 @@ void GraphRows::init( TraceEvents &trace_events )
         }
     }
 
+    // drm sched timeline
+    {
+        std::string ring;
+
+        for ( std::string ring : trace_events.m_drm_sched.rings)
+        {
+            if ( strncmp( "drm sched", ring.c_str(), 9 ) )
+                continue;
+
+            if ( (plocs = trace_events.get_locs( ring.c_str(), &type ) ) )
+                push_row( ring, type, plocs->size() );
+        }
+    }
+
     if ( ( plocs = trace_events.get_locs( "cpu graph", &type ) ) )
     {
         push_row( "cpu graph", type, plocs->size(), false );


### PR DESCRIPTION
Import generic drm scheduler events in to AMD timelime.
DRM scheduler is based on AMD scheduler, so the semantics are mostly the
same.

Signed-off-by: Robert Beckett <bob.beckett@collabora.com>