### PR TITLE
Run trace-cmd-status.sh script from scripts location

### DIFF
--- a/sample/trace-cmd-capture.sh
+++ b/sample/trace-cmd-capture.sh
@@ -8,7 +8,8 @@ fi
 
 if [ ${TRACE_ENABLED} -eq 0 ]; then
     echo -e "ERROR: Tracing is disabled\n"
-    ./trace-cmd-status.sh
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    ${SCRIPT_DIR}/trace-cmd-status.sh
     exit -1
 fi
 

--- a/sample/trace-cmd-start-tracing.sh
+++ b/sample/trace-cmd-start-tracing.sh
@@ -90,4 +90,6 @@ if [ "${USE_I915_PERF}" ]; then
 fi
 
 echo
-./trace-cmd-status.sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${SCRIPT_DIR}/trace-cmd-status.sh

--- a/sample/trace-cmd-stop-tracing.sh
+++ b/sample/trace-cmd-stop-tracing.sh
@@ -14,4 +14,5 @@ if [ "${USE_I915_PERF} " ]; then
     $CMD
 fi
 
-./trace-cmd-status.sh
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${SCRIPT_DIR}/trace-cmd-status.sh


### PR DESCRIPTION
When executing one of the other scripts run trace-cmd-status.sh from the
location of this script. This way it is of no influence if the current
working directory is different.

There is a common way to put the script location into an environment variable
what is done here.