### PR TITLE
Don't try to access i915-perf data if no file was given

### DIFF
--- a/src/gpuvis_i915_perfcounters.cpp
+++ b/src/gpuvis_i915_perfcounters.cpp
@@ -98,6 +98,9 @@ void I915PerfCounters::init( TraceEvents &trace_events )
 
     m_counters.clear();
 
+    if (!m_trace_events->i915_perf_reader)
+        return;
+
     const struct intel_perf_metric_set *metric_set =
         m_trace_events->i915_perf_reader->metric_set;
 


### PR DESCRIPTION
With USE_I915_PERF=1, if the user opens a .dat file without a
.i915-dat one, we run into a segfault... Oopsie