### PR TITLE
i915-perf: add GPU frequency plot

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -768,12 +768,8 @@ int MainApp::load_etl_file( loading_info_t *loading_info, TraceEvents &trace_eve
 
 int MainApp::load_i915_perf_file( loading_info_t *loading_info, TraceEvents &trace_events, EventCallback trace_cb )
 {
-#ifdef USE_I915_PERF
     return read_i915_perf_file( loading_info->filename.c_str(), trace_events.m_strpool,
         trace_events.m_trace_info, &trace_events.i915_perf_reader, trace_cb );
-#else
-    return 0;
-#endif
 }
 
 int SDLCALL MainApp::thread_func( void *data )

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -2125,6 +2125,8 @@ void TraceEvents::init_i915_perf_event( trace_event_t &event )
         event.id_start = m_i915.perf_locs.back();
     else
     {
+        // Figure out which kernel trace point triggered this GPU generated
+        // event.
         for ( uint32_t i = 1; i <= event.id; i++ )
         {
             const trace_event_t &req_event = m_events[ event.id - i ];

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -2919,6 +2919,11 @@ const std::vector< uint32_t > *TraceEvents::get_locs( const char *name,
         type = LOC_TYPE_i915Perf;
         plocs = &m_i915.perf_locs;
     }
+    else if ( !strcmp( name, "i915-perf-freq" ) )
+    {
+        type = LOC_TYPE_i915PerfFreq;
+        plocs = &m_i915.perf_locs;
+    }
     else if ( !strncmp( name, "plot:", 5 ) )
     {
         GraphPlot *plot = get_plot_ptr( name );

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -3421,6 +3421,12 @@ void TraceWin::trace_render_info()
 
         ImGui::EndColumns();
     }
+
+    if ( m_trace_events.i915_perf_reader &&
+         ImGui::CollapsingHeader( "i915-perf info" ) )
+    {
+        m_i915_perf.counters.show_record_info( m_trace_events );
+    }
 }
 
 void TraceWin::graph_center_event( uint32_t eventid )

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -24,6 +24,7 @@
 
 extern "C" {
     struct intel_perf_data_reader;
+    struct intel_perf_logical_counter;
 }
 
 // Opts singleton
@@ -149,6 +150,10 @@ public:
 
     bool init( TraceEvents &trace_events, const std::string &name,
                const std::string &filter_str, const std::string scanf_str );
+
+    void init_empty( const std::string &name );
+
+    void add_item( uint32_t eventid, int64_t ts, float value );
 
     uint32_t find_ts_index( int64_t ts0 );
 
@@ -449,6 +454,8 @@ public:
     }
     uint32_t ts_to_ftrace_print_info_idx( const std::vector< uint32_t > &locs, int64_t ts );
 
+    void add_i915_perf_frequency( const trace_event_t &event, int64_t ts, float value );
+
 public:
     // Called once on background thread after all events loaded.
     void init();
@@ -537,6 +544,12 @@ public:
         util_umap< uint32_t, uint32_t > perf_to_req_in;
         // Maps a HW context ID to its color
         std::map< uint32_t, ImU32 > perf_hw_context_colors;
+
+        // Frequency counter, filled right after parsing the i915-perf data.
+        struct intel_perf_logical_counter *frequency_counter = NULL;
+        // Plot generated after i915-perf data is parsed with the frequency
+        // counter values.
+        GraphPlot freq_plot;
     } m_i915;
 
     struct ftrace_pair_t

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -47,6 +47,7 @@ enum loc_type_t
     LOC_TYPE_i915RequestWait,
     LOC_TYPE_i915Request,
     LOC_TYPE_i915Perf, // GPU generated data
+    LOC_TYPE_i915PerfFreq, // GPU generated data
     LOC_TYPE_Max
 };
 
@@ -793,7 +794,8 @@ protected:
     // Render cpus print row
     uint32_t graph_render_cpus_timeline( graph_info_t &gi );
     // Render plot row
-    uint32_t graph_render_plot( graph_info_t &gi );
+    uint32_t graph_render_row_plot( graph_info_t &gi );
+    uint32_t graph_render_plot( graph_info_t &gi, GraphPlot &plot );
     // Render regular trace events
     uint32_t graph_render_row_events( graph_info_t &gi );
     // Render intel i915 request_wait events
@@ -802,6 +804,8 @@ protected:
     uint32_t graph_render_i915_req_events( graph_info_t &gi );
     // Render intel i915-perf events (GPU generated data)
     uint32_t graph_render_i915_perf_events( graph_info_t &gi );
+    // Render intel i915-perf frequency data (GPU generated data)
+    uint32_t graph_render_i915_perf_freq( graph_info_t &gi );
 
     // Render graph decorations
     void graph_render_time_ticks( graph_info_t &gi, float h0, float h1 );

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -706,6 +706,8 @@ public:
 
     void render();
 
+    void show_record_info( TraceEvents &trace_events );
+
     /* Associated process to a given i915-perf event. */
     struct i915_perf_process {
         const char *label;

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -2501,6 +2501,10 @@ uint32_t TraceWin::graph_render_i915_perf_events( graph_info_t &gi )
         }
         const trace_event_t &event = get_event( eventid );
 
+        // Skip idle events
+        if ( event.pid == 0xffffffff )
+            continue;
+
         if ( eventid > gi.eventend )
             break;
         else if ( gi.graph_only_filtered && event.is_filtered_out )

--- a/src/gpuvis_graphrows.cpp
+++ b/src/gpuvis_graphrows.cpp
@@ -319,7 +319,10 @@ void GraphRows::init( TraceEvents &trace_events )
     // Intel gpu events
     {
         if ( !trace_events.m_i915.perf_locs.empty() )
+        {
             push_row( "i915-perf", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+            push_row( "i915-perf-freq", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+        }
 
         for ( auto &req_locs : trace_events.m_i915.req_locs.m_locs.m_map )
         {

--- a/src/gpuvis_i915_perfcounters.cpp
+++ b/src/gpuvis_i915_perfcounters.cpp
@@ -275,6 +275,53 @@ void I915PerfCounters::render()
     ImGui::EndChild();
 }
 
+void I915PerfCounters::show_record_info( TraceEvents &trace_events )
+{
+    ImGui::Columns( 2, "##i915-record" );
+
+
+    ImGui::Text( "Number of GPU generated records");
+    ImGui::NextColumn();
+    ImGui::Text( "%u", trace_events.i915_perf_reader->n_records );
+    ImGui::NextColumn();
+    ImGui::Text( "Number of GPU timeline items");
+    ImGui::NextColumn();
+    ImGui::Text( "%u", trace_events.i915_perf_reader->n_timelines );
+    ImGui::NextColumn();
+    ImGui::Text( "Number of CPU/GPU correlation timestamp points" );
+    ImGui::NextColumn();
+    ImGui::Text( "%u", trace_events.i915_perf_reader->n_correlations );
+    ImGui::NextColumn();
+    ImGui::Text( "Metric set name" );
+    ImGui::NextColumn();
+    ImGui::Text( "%s", trace_events.i915_perf_reader->metric_set_name );
+    ImGui::NextColumn();
+    ImGui::Text( "Metric set uuid" );
+    ImGui::NextColumn();
+    ImGui::Text( "%s", trace_events.i915_perf_reader->metric_set_uuid );
+    ImGui::NextColumn();
+
+    const struct intel_perf *perf = trace_events.i915_perf_reader->perf;
+    if ( strlen( perf->devinfo.devname ) )
+    {
+        ImGui::Text( "Device name" );
+        ImGui::NextColumn();
+        ImGui::Text( "%s", perf->devinfo.devname );
+        ImGui::NextColumn();
+    }
+    if ( strlen( perf->devinfo.prettyname ) )
+    {
+        ImGui::Text( "Device pretty name" );
+        ImGui::NextColumn();
+        ImGui::Text( "%s", perf->devinfo.prettyname );
+        ImGui::NextColumn();
+    }
+    ImGui::Text( "Device execution units" );
+    ImGui::NextColumn();
+    ImGui::Text( "%lu", perf->devinfo.n_eus );
+    ImGui::EndColumns();
+}
+
 #else
 
 void I915PerfCounters::init( TraceEvents &trace_events )
@@ -294,6 +341,10 @@ I915PerfCounters::get_process( const trace_event_t &i915_perf_event )
 }
 
 void I915PerfCounters::render()
+{
+}
+
+void I915PerfCounters::show_record_info( TraceEvents &trace_events )
 {
 }
 

--- a/src/gpuvis_plots.cpp
+++ b/src/gpuvis_plots.cpp
@@ -353,6 +353,24 @@ bool GraphPlot::init( TraceEvents &trace_events, const std::string &name,
     return !m_plotdata.empty();
 }
 
+void GraphPlot::init_empty( const std::string &name )
+{
+    m_name = name;
+    m_filter_str.clear();
+    m_scanf_str.clear();
+
+    m_minval = FLT_MAX;
+    m_maxval = FLT_MIN;
+    m_plotdata.clear();
+}
+
+void GraphPlot::add_item( uint32_t eventid, int64_t ts, float value )
+{
+    m_minval = std::min< float >( m_minval, value );
+    m_maxval = std::max< float >( m_maxval, value );
+    m_plotdata.push_back( { ts, eventid, value } );
+}
+
 uint32_t GraphPlot::find_ts_index( int64_t ts0 )
 {
     auto lambda = []( const GraphPlot::plotdata_t &lhs, int64_t ts )

--- a/src/i915-perf/i915-perf-read.cpp
+++ b/src/i915-perf/i915-perf-read.cpp
@@ -75,6 +75,7 @@ int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace
 
     for (uint32_t i = 0; i < reader->n_timelines; i++)
     {
+        // Skip the idle time
         if ( reader->timelines[i].hw_id == 0xffffffff )
             continue;
 

--- a/src/i915-perf/i915-perf-read.cpp
+++ b/src/i915-perf/i915-perf-read.cpp
@@ -75,10 +75,6 @@ int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace
 
     for (uint32_t i = 0; i < reader->n_timelines; i++)
     {
-        // Skip the idle time
-        if ( reader->timelines[i].hw_id == 0xffffffff )
-            continue;
-
         trace_event_t event;
 
         if ( reader->timelines[i].cpu_ts_start < trace_info.min_file_ts )

--- a/src/i915-perf/i915-perf-read.h
+++ b/src/i915-perf/i915-perf-read.h
@@ -25,8 +25,22 @@
 #ifndef I915_PERF_READ_H_
 #define I915_PERF_READ_H_
 
-struct intel_perf_data_reader;
+#include <functional>
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+extern "C" {
+    struct intel_perf_data_reader;
+    struct intel_perf_logical_counter;
+}
+
+typedef std::function< void ( const trace_event_t &event, int64_t ts, float value ) > I915CounterCallback;
 
 int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace_info, struct intel_perf_data_reader **reader, EventCallback &cb );
+struct intel_perf_logical_counter *get_i915_perf_frequency_counter( struct intel_perf_data_reader *reader );
+void load_i915_perf_counter_values( struct intel_perf_data_reader *reader,
+                                    struct intel_perf_logical_counter *counter,
+                                    const trace_event_t &event, I915CounterCallback &cb );
 
 #endif // I915_PERF_READ_H_


### PR DESCRIPTION
i915-perf reports generated by the GPU carry frequency information, we can just extract that and plot it (reusing the existing plotting code)

![Screenshot from 2020-12-30 13-53-41](https://user-images.githubusercontent.com/434333/103352715-4e627000-4aa7-11eb-8f02-c16fa11f33ac.png)
