### PR TITLE
trace-read: Fix high-prec vblank timestamps

### DIFF
--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1739,7 +1739,7 @@ static int trace_enum_events( trace_data_t &trace_data, tracecmd_input_t *handle
                     unsigned long long val = pevent_read_number( pevent,
                                ( char * )record->data + format->offset, format->size );
 
-                    trace_event.vblank_ts = val - trace_data.trace_info.min_file_ts;
+                    trace_event.vblank_ts = val;
                 }
                 else if ( trace_event.name == trace_data.drm_vblank_event_str &&
                           format_name == trace_data.high_prec_str &&


### PR DESCRIPTION
Do not subtract `min_file_ts` when assigning the high-prec vblank
timestamp.

This fixes a regression of high-prec vblank TS not showing up,
introduced by 93f2f67f963e8ea8e42c2199fa43c97477d409fd