### PR TITLE
i915-perf: set a different default colors to GPU timeline events

### DIFF
--- a/src/gpuvis_colors.inl
+++ b/src/gpuvis_colors.inl
@@ -68,7 +68,6 @@ _XTAG( col_Graph_TaskRunning, 0x4fff00ff, "Sched_switch task running block" )
 _XTAG( col_Graph_TaskSleeping, 0x4fffff00, "Sched_switch task sleeping block" )
 
 _XTAG( col_Graph_Bari915ReqWait, 0x4f0000ff, "i915 reqwait bar" )
-_XTAG( col_Graph_i915Perf, 0xff9b9400, "i915-perf bar" )
 
 _XTAG( col_Graph_Bari915Queue, 0xc81d740c, "Request queued waiting to be added" )
 _XTAG( col_Graph_Bari915SubmitDelay, 0xc8f8552e, "Requests waiting on fences and dependencies before they are runnable" )

--- a/src/gpuvis_i915_perfcounters.cpp
+++ b/src/gpuvis_i915_perfcounters.cpp
@@ -191,7 +191,7 @@ I915PerfCounters::get_process( const trace_event_t &i915_perf_event )
 {
     i915_perf_process process;
     process.label = "<unknown>";
-    process.color = s_clrs().get( col_Graph_i915Perf );
+    process.color = i915_perf_event.color;
 
     uint32_t *req_event_id = m_trace_events->m_i915.perf_to_req_in.get_val( i915_perf_event.id );
 


### PR DESCRIPTION
By default we're currently using the same color for all GPU timeline
events. But some i915 driver versions don't have tracepoint support to
build correlation back to the process that submitted the work, so that
we can use the process' color.

So just assign a default color so that we can at least tell items
apart on the timeline.