### PR TITLE
Better i915-perf / tracepoint tracking

### DIFF
--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -117,6 +117,7 @@ public:
 
     static uint32_t get_i915_ringno( const trace_event_t &event, bool *is_class_instance = nullptr );
     static uint32_t get_i915_hw_id( const trace_event_t &event);
+    static uint32_t get_i915_seqno( const trace_event_t &event );
 
 public:
     // Map of db_key to array of event locations.

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -727,6 +727,7 @@ public:
     struct i915_perf_process {
         const char *label;
         ImU32 color;
+        const trace_event_t *event;
     };
 
     i915_perf_process get_process( const trace_event_t &event );

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -2555,6 +2555,9 @@ uint32_t TraceWin::graph_render_i915_perf_events( graph_info_t &gi )
             if ( gi.mouse_pos_in_rect( { x0, y, x1 - x0, row_h } ) )
             {
                 imgui_drawrect( x0, y, x1 - x0, row_h, s_clrs().get( col_Graph_BarSelRect ) );
+
+                gi.set_selected_i915_ringctxseq( *process.event );
+
                 gi.i915_perf_bars.push_back( event.id );
 
                 m_i915_perf.counters.set_event( event );

--- a/src/gpuvis_i915_perfcounters.cpp
+++ b/src/gpuvis_i915_perfcounters.cpp
@@ -192,16 +192,19 @@ I915PerfCounters::get_process( const trace_event_t &i915_perf_event )
     i915_perf_process process;
     process.label = "<unknown>";
     process.color = i915_perf_event.color;
+    process.event = NULL;
 
     uint32_t *req_event_id = m_trace_events->m_i915.perf_to_req_in.get_val( i915_perf_event.id );
 
     if ( req_event_id )
     {
-        const trace_event_t &req_event = m_trace_events->m_events[ *req_event_id ];
-        process.label = req_event.comm;
+        const trace_event_t *req_event = &m_trace_events->m_events[ *req_event_id ];
+        process.label = req_event->comm;
+        process.event = req_event;
+
 
         const std::vector< uint32_t > *sched_plocs =
-            m_trace_events->get_sched_switch_locs( req_event.pid,
+            m_trace_events->get_sched_switch_locs( req_event->pid,
                                                    TraceEvents::SCHED_SWITCH_PREV );
         if ( sched_plocs )
         {


### PR DESCRIPTION
Some recent (probably a couple of years :() changes in i915 have made the tracking of GPU generated data to tracepoint a bit different.

Here are a couple of commits to resolve that issue without breaking the correlation on older kernels.