### PR TITLE
Improve archive handling

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -602,12 +602,18 @@ static std::string unzip_first_file( const char *zipfile )
 
             if ( mz_zip_reader_extract_to_file( &zip_archive, i, ret.c_str(), 0 ) )
                 break;
+            else
+                logf( "[Error] %s failed to extract from %s (src: %s, dest: %s).",
+                        __func__, zipfile, file_stat.m_filename, ret.c_str() );
 
             ret.clear();
         }
 
         mz_zip_reader_end( &zip_archive );
     }
+    else
+        logf( "[Error] %s could not open archive %s.",
+                __func__, zipfile );
 
     return ret;
 }

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -1242,6 +1242,7 @@ public:
         TraceWin *win = nullptr;
         SDL_Thread *thread = nullptr;
         std::vector< std::string > inputfiles;
+        std::unordered_set< std::string > tmpfiles;
 
         bool last;
     };


### PR DESCRIPTION
This patchset simplifies and expands existing zip file opening capabilities by removing unnecessary platform specific code, adding the ability to open archives containing more than one trace file, and performing cleanup of generated temporary files once they are no longer needed.