### PR TITLE
Enable Shortcut for gpuvis Desktop Application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ endif
 # Investigate: Improving C++ Builds with Split DWARF
 #  http://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/
 
-CFLAGS = $(WARNINGS) -march=native -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf $(SDL2FLAGS) $(GTK3FLAGS) $(I915_PERF_CFLAGS) -I/usr/include/freetype2
+CFLAGS = $(WARNINGS) -mcpu=native -mtune=native -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf $(SDL2FLAGS) $(GTK3FLAGS) $(I915_PERF_CFLAGS) -I/usr/include/freetype2
 CFLAGS += -DUSE_FREETYPE -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
 CXXFLAGS = -fno-rtti -Woverloaded-virtual 
-LDFLAGS = -march=native -gdwarf-4 -g2 -Wl,--build-id=sha1
+LDFLAGS = -mcpu=native -mtune=native -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lfreetype -lstdc++ $(SDL2LIBS) $(I915_PERF_LIBS)
 
 ifneq ("$(wildcard /usr/bin/ld.gold)","")

--- a/gpuvis.desktop
+++ b/gpuvis.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=gpuvis
+GenericName=GPU Trace Visualizer
+Comment=gpuvis desktop application
+Exec=gpuvis
+Icon=gpuvis
+Terminal=false
+Type=Application
+Categories=Graphics;

--- a/gpuvis.metainfo.xml
+++ b/gpuvis.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>gpuvis.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>gpuvis</name>
+  <summary>A GPU Trace Visualizer</summary>
+  <description>
+    <p>
+      Gpuvis is a Linux GPU profiler similar to GPUView on Windows. 
+      It is designed to work with trace-cmd captures and help track 
+      down Linux gpu and application performance issues.
+    </p>
+    <p>
+      Gpuvis is open-source, so feel free to contribute new features!
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/mikesart/gpuvis/master/images/gpuvis.jpg</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/mikesart/gpuvis/wiki</url>
+  <update_contact>mikesart@fastmail.com</update_contact>
+</component>


### PR DESCRIPTION
Added .desktop file and appdata files to enable it as a shortcut
for easy launch from Linux desktop when installed as an RPM package
Update Makefile to support building on ppc64le arch

Signed-off-by: Dorinda Bassey <dbassey@redhat.com>