### PR TITLE
Add RapidJSON dependency in Meson BuildSystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ ifneq ($(COMPILER),clang)
   NO_POINTER_SIGN =
   NO_CLOBBERED = -Wno-clobbered
   NO_SUGGEST_ATTRIBUTE_FORMAT = -Wno-suggest-attribute=format
-  MCPU_OPT = -mcpu=native
 else
   NO_MAYBE_UNINITIALIZED =
   NO_OLD_STYLE_DECLARATION =
@@ -71,16 +70,15 @@ else
   NO_POINTER_SIGN = -Wno-pointer-sign
   NO_CLOBBERED =
   NO_SUGGEST_ATTRIBUTE_FORMAT =
-  MCPU_OPT =
 endif
 
 # Investigate: Improving C++ Builds with Split DWARF
 #  http://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/
 
-CFLAGS = $(WARNINGS) $(MCPU_OPT) -mtune=native -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf $(SDL2FLAGS) $(GTK3FLAGS) $(I915_PERF_CFLAGS) -I/usr/include/freetype2
+CFLAGS = $(WARNINGS) -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf $(SDL2FLAGS) $(GTK3FLAGS) $(I915_PERF_CFLAGS) -I/usr/include/freetype2
 CFLAGS += -DUSE_FREETYPE -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
 CXXFLAGS = -fno-rtti -Woverloaded-virtual $(CXXWARNINGS)
-LDFLAGS = $(MCPU_OPT) -mtune=native -gdwarf-4 -g2 -Wl,--build-id=sha1
+LDFLAGS = -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lfreetype -lstdc++ $(SDL2LIBS) $(I915_PERF_LIBS)
 
 ifneq ("$(wildcard /usr/bin/ld.gold)","")

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,11 @@ if get_option('use_i915_perf')
   all_deps += dependency('i915-perf')
 endif
 
+if get_option('have_rapidjson')
+  compile_flags += '-DHAVE_RAPIDJSON=1'
+  all_deps += dependency('RapidJSON')
+endif
+
 gpuvis_files = files(
   'src/gpuvis.cpp',
   'src/gpuvis_graph.cpp',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('use_freetype', type : 'boolean', value : 'true')
 option('use_gtk3', type : 'boolean', value : 'true')
 option('use_i915_perf', type : 'boolean', value : 'false')
+option('have_rapidjson', type : 'boolean', value : 'true')


### PR DESCRIPTION
This RapidJSON dependency added in the Meson Build is needed for loading
of Linux perf JSON. see reference - https://github.com/mikesart/gpuvis/pull/64

Signed-off-by: Dorinda Bassey <dbassey@redhat.com>