### PR TITLE
fix build using meson and not vendor rapidjson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ project( "gpuvis" )
 
 option(USE_FREETYPE "USE_FREETYPE" ON)
 option(USE_I915_PERF "USE_I915_PERF" OFF)
+option(USE_RAPIDJSON "USE_RAPIDJSON" ON)
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
@@ -87,18 +88,10 @@ if ( USE_I915_PERF )
     ucm_add_flags( -DUSE_I915_PERF )
 endif()
 
-# Fetch RapidJSON
-set(RAPIDJSON_URL https://github.com/Tencent/rapidjson/archive/1c2c8e085a8b2561dff17bedb689d2eb0609b689.tar.gz)
-set(RAPIDJSON_DEP lib/rapidjson/include/rapidjson/rapidjson.h)
-if(NOT EXISTS "${PROJECT_SOURCE_DIR}/${RAPIDJSON_DEP}")
-    message("Downloading RapidJSON...")
-    file(DOWNLOAD ${RAPIDJSON_URL} "${PROJECT_SOURCE_DIR}/lib/rapidjson.tar.gz")
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_SOURCE_DIR}/lib/rapidjson.tar.gz WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
-    file(RENAME ${PROJECT_SOURCE_DIR}/lib/rapidjson-1c2c8e085a8b2561dff17bedb689d2eb0609b689 ${PROJECT_SOURCE_DIR}/lib/rapidjson)
+if ( USE_RAPIDJSON )
+    find_package( RapidJSON REQUIRED )
+    ucm_add_flags( -DHAVE_RAPIDJSON )
 endif()
-ucm_add_flags( -DHAVE_RAPIDJSON )
-include_directories( ${PROJECT_SOURCE_DIR}/lib/rapidjson/include )
-
 
 ucm_print_flags()
 
@@ -145,6 +138,7 @@ include_directories(
     ${FREETYPE_INCLUDE_DIRS}
     ${GTK3_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
+    ${RAPIDJSON_INCLUDE_DIRS}
     ${I915_PERF_INCLUDE_DIRS}
     )
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ NAME = gpuvis
 
 USE_GTK3 ?= 1
 USE_I915_PERF ?= 0
+USE_RAPIDJSON ?= 1
 CFG ?= release
 ifeq ($(CFG), debug)
     ASAN ?= 1
@@ -31,18 +32,6 @@ MKDIR = mkdir -p
 VERBOSE ?= 0
 
 COMPILER = $(shell $(CC) -v 2>&1 | grep -q "clang version" && echo clang || echo gcc)
-
-SDL2FLAGS=$(shell sdl2-config --cflags)
-SDL2LIBS=$(shell sdl2-config --libs)
-
-ifeq ($(USE_GTK3), 1)
-GTK3FLAGS=$(shell pkg-config --cflags gtk+-3.0) -DUSE_GTK3
-endif
-
-ifeq ($(USE_I915_PERF), 1)
-I915_PERF_CFLAGS=$(shell pkg-config --cflags i915-perf) -DUSE_I915_PERF
-I915_PERF_LIBS=$(shell pkg-config --libs i915-perf)
-endif
 
 WARNINGS = -Wall -Wextra -Wpedantic -Wmissing-include-dirs -Wformat=2 -Wshadow \
 	-Wno-unused-parameter -Wno-missing-field-initializers -Wno-variadic-macros
@@ -75,11 +64,32 @@ endif
 # Investigate: Improving C++ Builds with Split DWARF
 #  http://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/
 
-CFLAGS = $(WARNINGS) -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf $(SDL2FLAGS) $(GTK3FLAGS) $(I915_PERF_CFLAGS) -I/usr/include/freetype2 -Isrc/libtraceevent/include
+CFLAGS = $(WARNINGS) -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf
 CFLAGS += -DUSE_FREETYPE -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
 CXXFLAGS = -fno-rtti -Woverloaded-virtual $(CXXWARNINGS)
 LDFLAGS = -gdwarf-4 -g2 -Wl,--build-id=sha1
-LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lfreetype -lstdc++ $(SDL2LIBS) $(I915_PERF_LIBS)
+LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lstdc++
+
+CFLAGS += $(shell sdl2-config --cflags)
+LIBS += $(shell sdl2-config --libs)
+
+ifeq ($(USE_GTK3), 1)
+CFLAGS += $(shell pkg-config --cflags gtk+-3.0) -DUSE_GTK3
+endif
+
+ifeq ($(USE_I915_PERF), 1)
+CFLAGS += $(shell pkg-config --cflags i915-perf) -DUSE_I915_PERF
+LIBS += $(shell pkg-config --libs i915-perf)
+endif
+
+ifeq ($(USE_RAPIDJSON), 1)
+CFLAGS += $(shell pkg-config --cflags RapidJSON) -DHAVE_RAPIDJSON
+endif
+
+CFLAGS += $(shell pkg-config --cflags freetype2)
+LIBS += $(shell pkg-config --libs freetype2)
+
+CFLAGS +=  -Isrc/libtraceevent/include
 
 ifneq ("$(wildcard /usr/bin/ld.gold)","")
   $(info Using gold linker...)
@@ -172,14 +182,6 @@ $(info Building $(ODIR)/$(NAME)...)
 C_OBJS = ${CFILES:%.c=${ODIR}/%.o}
 OBJS = ${C_OBJS:%.cpp=${ODIR}/%.o}
 
-# Fetch RapidJSON
-CFLAGS += -DHAVE_RAPIDJSON -Ilib/rapidjson/include
-RAPIDJSON_URL = https://github.com/Tencent/rapidjson/archive/1c2c8e085a8b2561dff17bedb689d2eb0609b689.tar.gz
-RAPIDJSON_DEP = lib/rapidjson/include/rapidjson/rapidjson.h
-$(RAPIDJSON_DEP):
-	@mkdir -p lib/rapidjson
-	curl -Lo- "$(RAPIDJSON_URL)" | tar -xzf- --strip-components=1 -Clib/rapidjson
-
 all: $(PROJ)
 
 $(ODIR)/$(NAME): $(OBJS)
@@ -206,12 +208,12 @@ $(ODIR)/src/libtraceevent/src/event-parse-api.o: CFLAGS += -Wno-pedantic
 $(ODIR)/src/imgui/imgui.o: CXXFLAGS += $(NO_STRINGOP_TRUNCATION)
 $(ODIR)/src/trace-cmd/trace-read.o: CXXFLAGS += $(NO_CLOBBERED)
 
-$(ODIR)/%.o: %.c Makefile $(RAPIDJSON_DEP)
+$(ODIR)/%.o: %.c Makefile
 	$(VERBOSE_PREFIX)echo "---- $< ----";
 	@$(MKDIR) $(dir $@)
 	$(VERBOSE_PREFIX)$(CC) -MMD -MP -std=gnu99 $(CFLAGS) -o $@ -c $<
 
-$(ODIR)/%.o: %.cpp Makefile $(RAPIDJSON_DEP)
+$(ODIR)/%.o: %.cpp Makefile
 	$(VERBOSE_PREFIX)echo "---- $< ----";
 	@$(MKDIR) $(dir $@)
 	$(VERBOSE_PREFIX)$(CXX) -MMD -MP -std=c++11 $(CFLAGS) $(CXXFLAGS) -o $@ -c $<
@@ -224,4 +226,3 @@ clean:
 	$(VERBOSE_PREFIX)$(RM) $(OBJS)
 	$(VERBOSE_PREFIX)$(RM) $(OBJS:.o=.d)
 	$(VERBOSE_PREFIX)$(RM) $(OBJS:.o=.dwo)
-	$(VERBOSE_PREFIX)$(RM) -r lib/rapidjson

--- a/meson.build
+++ b/meson.build
@@ -66,14 +66,20 @@ gpuvis_files = files(
   'src/imgui/imgui_freetype.cpp',
   'src/GL/gl3w.c',
   'src/i915-perf/i915-perf-read.cpp',
-  'src/trace-cmd/event-parse.c',
-  'src/trace-cmd/trace-seq.c',
-  'src/trace-cmd/kbuffer-parse.c',
+  'src/libtraceevent/src/event-parse.c',
+  'src/libtraceevent/src/event-parse-api.c',
+  'src/libtraceevent/src/event-plugin.c',
+  'src/libtraceevent/src/kbuffer-parse.c',
+  'src/libtraceevent/src/parse-utils.c',
+  'src/libtraceevent/src/trace-seq.c',
   'src/trace-cmd/trace-read.cpp',
 )
+
+incdir = include_directories('src/libtraceevent/include')
 
 executable('gpuvis', gpuvis_files,
            c_args : compile_flags,
            cpp_args : compile_flags,
            dependencies : all_deps,
-           install : true)
+           install : true,
+           include_directories : incdir)


### PR DESCRIPTION
This makes the meson build up to date with the rest, and also stop downloading rapidjson from the web and get it from the system like other libs.

tbh why is there 3 build system?
