### PR TITLE
Update i915 specific support for GPUvis

### DIFF
--- a/sample/trace-cmd-start-tracing.sh
+++ b/sample/trace-cmd-start-tracing.sh
@@ -17,6 +17,16 @@ if [ "${USE_I915_PERF}" ]; then
         echo "WARNING: Missing I915_PERF_METRIC value. Using default value 'RenderBasic'."
         I915_PERF_METRIC="RenderBasic"
     fi
+
+    if [ -z "${I915_PERF_ENGINE_CLASS}" ]; then
+        echo "WARNING: Missing I915_PERF_ENGINE_CLASS value. Using default value 0 (Render Class)."
+        I915_PERF_ENGINE_CLASS=0
+    fi
+
+    if [ -z "${I915_PERF_ENGINE_INSTANCE}" ]; then
+        echo "WARNING: Missing I915_PERF_ENGINE_INSTANCE value. Using default instance 0."
+        I915_PERF_ENGINE_INSTANCE=0
+    fi
 fi
 
 EVENTS=
@@ -84,7 +94,7 @@ if [ -e /tmp/.i915-perf-record ]; then
 fi
 
 if [ "${USE_I915_PERF}" ]; then
-    CMD="i915-perf-recorder -m ${I915_PERF_METRIC} -s 8000 -k ${CLOCK}"
+    CMD="i915-perf-recorder -m ${I915_PERF_METRIC} -s 8000 -k ${CLOCK} -e ${I915_PERF_ENGINE_CLASS} -i ${I915_PERF_ENGINE_INSTANCE}"
     echo $CMD
     $CMD &
 fi

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -2305,7 +2305,7 @@ void TraceEvents::add_i915_perf_frequency( const trace_event_t &event, int64_t t
 
 void TraceEvents::init_i915_perf_event( trace_event_t &event )
 {
-    if ( !event.has_duration() )
+    if ( !event.has_duration() && !m_i915.perf_locs.empty())
         event.id_start = m_i915.perf_locs.back();
     else
     {

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -2614,7 +2614,8 @@ uint32_t TraceWin::graph_render_i915_perf_events( graph_info_t &gi )
             {
                 imgui_drawrect( x0, y, x1 - x0, row_h, s_clrs().get( col_Graph_BarSelRect ) );
 
-                gi.set_selected_i915_ringctxseq( *process.event );
+                if (process.event != NULL)
+                    gi.set_selected_i915_ringctxseq( *process.event );
 
                 gi.i915_perf_bars.push_back( event.id );
 

--- a/src/i915-perf/i915-perf-read.cpp
+++ b/src/i915-perf/i915-perf-read.cpp
@@ -114,10 +114,10 @@ int read_i915_perf_file( const char *file, StrPool &strpool, trace_info_t &trace
 }
 
 #if USE_I915_PERF
-static uint32_t record_timestamp( const struct drm_i915_perf_record_header *record )
+static uint64_t record_timestamp( struct intel_perf_data_reader *reader,
+                                  const struct drm_i915_perf_record_header *record )
 {
-    const uint32_t *data = ( const uint32_t * )( record + 1 );
-    return data[ 1 ];
+    return intel_perf_read_record_timestamp(reader->perf, reader->metric_set, record);
 }
 #endif
 
@@ -134,7 +134,7 @@ void load_i915_perf_counter_values( struct intel_perf_data_reader *reader,
     {
         const struct drm_i915_perf_record_header *record = reader->records[j];
         int64_t ts = item->cpu_ts_start +
-            ( record_timestamp( record ) - record_timestamp( first_record ) ) *
+            ( record_timestamp( reader, record ) - record_timestamp( reader, first_record ) ) *
             ( item->cpu_ts_end - item->cpu_ts_start ) / ( item->ts_end - item->ts_start );
         struct intel_perf_accumulator acc;
 


### PR DESCRIPTION
A bunch of updates are included here

1) Fix crashes on some corner cases by adding additional checks
2) Use the timestamp API exposed by perf library
3) Enable scripts to select specific OA units