### PR TITLE
Actually delete the correct keys after processing a begin/end event.

### DIFF
--- a/src/gpuvis_ftrace_print.cpp
+++ b/src/gpuvis_ftrace_print.cpp
@@ -457,8 +457,8 @@ void TraceEvents::new_event_ftrace_print( trace_event_t &event )
                     event0.color_index = event0.color_index;
 
                 // Erase all knowledge of this ctx so it can be reused
-                m_ftrace.begin_ctx.erase_key( event.seqno );
-                m_ftrace.end_ctx.erase_key( event.seqno );
+                m_ftrace.begin_ctx.erase_key( key );
+                m_ftrace.end_ctx.erase_key( key );
 
                 add_event = &event0;
             }


### PR DESCRIPTION
The key with which we add them is not just event.seqno, so we shouldn't use just seqno for deletion either.

Fixes begin/end events when we reuse the context ids on a thread. That way I can e.g. just use stackdepth.