### PR TITLE
Include <cstdint> in gpuvis_macros.h

### DIFF
--- a/src/gpuvis_macros.h
+++ b/src/gpuvis_macros.h
@@ -104,6 +104,8 @@ char *strtok_r( char *str, const char *delim, char **saveptr );
 
 #if defined( __cplusplus )
 
+#include <cstdint>
+
 template < typename K, typename V >
 class util_umap
 {


### PR DESCRIPTION
Fixes errors such as:

    In file included from ../src/stlini.cpp:61:
    ../src/gpuvis_macros.h:200:26: error: ‘uint64_t’ has not been declared
      200 |     const char *findstr( uint64_t hashval );
          |                          ^~~~~~~~
    ../src/gpuvis_macros.h:202:5: error: ‘uint64_t’ does not name a type
      202 |     uint64_t getu64( const char *str, size_t len = ( size_t )-1 );
          |     ^~~~~~~~
    ../src/gpuvis_macros.h:30:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
       29 | #include "../sample/gpuvis_trace_utils.h"
      +++ |+#include <cstdint>
       30 |