### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,11 @@ elseif ( UNIX AND NOT APPLE )
     find_package( PkgConfig REQUIRED )
     pkg_check_modules( GTK3 REQUIRED gtk+-3.0 )
 
-    ucm_add_flags( -DUSE_GTK3 -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 )
+    ucm_add_flags( -DUSE_GTK3 )
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux|SunOS" OR MINGW)
+        ucm_add_flags( -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 )
+    endif()
+
     set( GTK3_LIBRARIES "" )
 
     LINK_LIBRARIES( dl )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ elseif ( UNIX AND NOT APPLE )
 
     set( GTK3_LIBRARIES "" )
 
-    LINK_LIBRARIES( dl )
+    LINK_LIBRARIES( ${CMAKE_DL_LIBS} )
 endif()
 
 if ( USE_I915_PERF )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ ucm_set_runtime( STATIC )
 ucm_add_flags( -O0 -DDEBUG CONFIG Debug )
 ucm_add_flags( -O2 -DNDEBUG CONFIG Release )
 
-if ( CMAKE_COMPILER_IS_GNUCC OR APPLE )
+if ( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang" )
     ucm_add_flags( CXX -std=c++11 )
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,17 @@ endif
 #  http://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/
 
 CFLAGS = $(WARNINGS) -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf
-CFLAGS += -DUSE_FREETYPE -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
+CFLAGS += -DUSE_FREETYPE
 CXXFLAGS = -fno-rtti -Woverloaded-virtual $(CXXWARNINGS)
 LDFLAGS = -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lstdc++
 
 CFLAGS += $(shell sdl2-config --cflags)
 LIBS += $(shell sdl2-config --libs)
+
+ifeq (, $(filter-out Linux SunOS,$(shell uname -s)))
+CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
+endif
 
 ifeq ($(USE_GTK3), 1)
 CFLAGS += $(shell pkg-config --cflags gtk+-3.0) -DUSE_GTK3

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,14 @@ CFLAGS = $(WARNINGS) -fno-exceptions -gdwarf-4 -g2 -ggnu-pubnames -gsplit-dwarf
 CFLAGS += -DUSE_FREETYPE
 CXXFLAGS = -fno-rtti -Woverloaded-virtual $(CXXWARNINGS)
 LDFLAGS = -gdwarf-4 -g2 -Wl,--build-id=sha1
-LIBS = -Wl,--no-as-needed -lm -ldl -lpthread -lstdc++
+LIBS = -Wl,--no-as-needed -lm -lpthread -lstdc++
 
 CFLAGS += $(shell sdl2-config --cflags)
 LIBS += $(shell sdl2-config --libs)
 
 ifeq (, $(filter-out Linux SunOS,$(shell uname -s)))
 CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
+LIBS += -ldl
 endif
 
 ifeq ($(USE_GTK3), 1)

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ c = meson.get_compiler('c')
 cc = meson.get_compiler('cpp')
 
 all_deps = [
-  cc.find_library('dl'),
+  cc.find_library('dl', required: false),
   dependency('sdl2'),
 ]
 compile_flags = [

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,11 @@ add_project_arguments(['-Wno-unused-parameter',
                        '-Wno-sign-compare'],
                       language: ['cpp'])
 
+if ['linux', 'sunos'].contains(host_machine.system())
+  add_project_arguments(['-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64'],
+                        language: ['c', 'cpp'])
+endif
+
 c = meson.get_compiler('c')
 cc = meson.get_compiler('cpp')
 

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('gpuvis', 'c', 'cpp',
         default_options : [
           'warning_level=2',
           'c_std=gnu99',
+          'cpp_std=c++11',
           'default_library=static',
         ],
         license : 'MIT',

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -20,10 +20,11 @@ endif
 CFLAGS = $(WARNINGS) -march=native -fno-exceptions -gdwarf-4 -g2
 CXXFLAGS = -fno-rtti -Woverloaded-virtual
 LDFLAGS = -march=native -gdwarf-4 -g2 -Wl,--build-id=sha1
-LIBS = -Wl,--no-as-needed -lGL -lX11 -lm -ldl -lpthread -lstdc++
+LIBS = -Wl,--no-as-needed -lGL -lX11 -lm -lpthread -lstdc++
 
 ifeq (, $(filter-out Linux SunOS,$(shell uname -s)))
 CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
+LIBS += -ldl
 endif
 
 CFILES = \

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -18,10 +18,13 @@ ifneq ($(COMPILER),clang)
 endif
 
 CFLAGS = $(WARNINGS) -march=native -fno-exceptions -gdwarf-4 -g2
-CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
 CXXFLAGS = -fno-rtti -Woverloaded-virtual
 LDFLAGS = -march=native -gdwarf-4 -g2 -Wl,--build-id=sha1
 LIBS = -Wl,--no-as-needed -lGL -lX11 -lm -ldl -lpthread -lstdc++
+
+ifeq (, $(filter-out Linux SunOS,$(shell uname -s)))
+CFLAGS += -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64
+endif
 
 CFILES = \
 	glxgears.c

--- a/src/gpuvis_macros.h
+++ b/src/gpuvis_macros.h
@@ -28,7 +28,7 @@
 #define GPUVIS_TRACE_UTILS_DISABLE
 #include "../sample/gpuvis_trace_utils.h"
 
-#if defined( __APPLE__ )
+#if !defined( __ANDROID__ ) && !defined( __GLIBC__ )
 // https://android.googlesource.com/platform/system/core/+/master/base/include/android-base/macros.h
 #ifndef TEMP_FAILURE_RETRY
 #define TEMP_FAILURE_RETRY(exp)            \

--- a/src/libtraceevent/include/linux/compiler.h
+++ b/src/libtraceevent/include/linux/compiler.h
@@ -122,7 +122,7 @@
 # define noinline
 #endif
 
-#if defined(__APPLE__) || defined(_WIN32) /* gpuvis change! */
+#if !defined(__linux__) /* gpuvis change! */
 #include <stdint.h>
 typedef uint8_t __u8;
 typedef uint16_t __u16;

--- a/src/libtraceevent/src/event-parse.c
+++ b/src/libtraceevent/src/event-parse.c
@@ -25,10 +25,11 @@ extern char *strtok_r(char *str, const char *delim, char **saveptr);
 #else
 #include <netinet/in.h>
 #include <sys/socket.h> /* gpuvis change! */
-#ifdef __APPLE__ /* gpuvis change! */
+#if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) || \
+  defined(__NetBSD__) || defined(__OpenBSD__) /* gpuvis change! */
 #define s6_addr16 __u6_addr.__u6_addr16
 #define s6_addr32 __u6_addr.__u6_addr32
-#endif /* __APPLE__ */
+#endif /* __APPLE__ || BSD */
 #endif /* _WIN32 */
 
 /* gpuvis change! See gpuvis_utils.cpp */

--- a/src/libtraceevent/src/event-parse.c
+++ b/src/libtraceevent/src/event-parse.c
@@ -24,6 +24,7 @@
 extern char *strtok_r(char *str, const char *delim, char **saveptr);
 #else
 #include <netinet/in.h>
+#include <sys/socket.h> /* gpuvis change! */
 #ifdef __APPLE__ /* gpuvis change! */
 #define s6_addr16 __u6_addr.__u6_addr16
 #define s6_addr32 __u6_addr.__u6_addr32

--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -50,7 +50,7 @@
 #include <sys/param.h>
 #include <unistd.h>
 
-#ifdef __APPLE__
+#if !defined(__linux__) && !defined(__sun)
 #define lseek64 lseek
 #define off64_t off_t
 #endif


### PR DESCRIPTION
BSD support is similar to macOS: actual tracing isn't implemented but one can still view existing traces (like [amdgpu_trace.zip](https://github.com/mikesart/gpuvis/blob/master/traces/amdgpu_trace.zip) in this repo). Tested under Sway after building on
```
$ c++ --version
FreeBSD clang version 16.0.6 (https://github.com/llvm/llvm-project.git llvmorg-16.0.6-0-g7cbf1a259152)
Target: x86_64-unknown-freebsd14.0
Thread model: posix
InstalledDir: /usr/bin
```
