### PR TITLE
Add support for perf traces from Intel Xe driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 
 if ( USE_I915_PERF )
     pkg_check_modules( I915_PERF REQUIRED i915-perf>=1.5.0)
+    pkg_check_modules( I915_PERF REQUIRED xe-oa )
     ucm_add_flags( -DUSE_I915_PERF )
 endif()
 

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ if get_option('use_i915_perf')
   compile_flags += '-DUSE_I915_PERF=1'
   all_deps += dependency('i915-perf',
                          version : '>= 1.5.0')
+  all_deps += dependency('xe-oa')
 endif
 
 if get_option('have_rapidjson')

--- a/sample/trace-cmd-capture.sh
+++ b/sample/trace-cmd-capture.sh
@@ -25,6 +25,11 @@ CMD="i915-perf-control -d trace_${DATE}.i915-dat"
 echo ${CMD}
 $CMD
 
+# Extract xe-perf trace
+CMD="xe-perf-control -d trace_${DATE}.xe-dat"
+echo ${CMD}
+$CMD
+
 # Extract trace
 CMD="trace-cmd extract -k -o trace_${DATE}.dat"
 echo ${CMD}

--- a/sample/trace-cmd-setup.sh
+++ b/sample/trace-cmd-setup.sh
@@ -83,8 +83,9 @@ else
     ROOT_CMDS+="chmod 0222 \"${TRACEFS}/trace_marker\"\n"
 fi
 
-# Enable i915-perf to collect GPU data.
+# Enable i915/xe perf to collect GPU data.
 ROOT_CMDS+="sysctl --ignore dev.i915.perf_stream_paranoid=0"
+ROOT_CMDS+="sysctl --ignore dev.xe.perf_stream_paranoid=0"
 
 if [ -z "${ROOT_CMDS}" ]; then
     :

--- a/sample/trace-cmd-start-tracing.sh
+++ b/sample/trace-cmd-start-tracing.sh
@@ -29,6 +29,23 @@ if [ "${USE_I915_PERF}" ]; then
     fi
 fi
 
+if [ "${USE_XE_PERF}" ]; then
+    if [ -z "${XE_PERF_METRIC}" ]; then
+        echo "WARNING: Missing XE_PERF_METRIC value. Using default value 'RenderBasic'."
+        XE_PERF_METRIC="RenderBasic"
+    fi
+
+    if [ -z "${XE_PERF_ENGINE_CLASS}" ]; then
+        echo "WARNING: Missing XE_PERF_ENGINE_CLASS value. Using default value 0 (Render Class)."
+        XE_PERF_ENGINE_CLASS=0
+    fi
+
+    if [ -z "${XE_PERF_ENGINE_INSTANCE}" ]; then
+        echo "WARNING: Missing XE_PERF_ENGINE_INSTANCE value. Using default instance 0."
+        XE_PERF_ENGINE_INSTANCE=0
+    fi
+fi
+
 EVENTS=
 
 # https://github.com/mikesart/gpuvis/wiki/TechDocs-Linux-Scheduler
@@ -93,8 +110,20 @@ if [ -e /tmp/.i915-perf-record ]; then
    $CMD
 fi
 
+if [ -e /tmp/.xe-perf-record ]; then
+   CMD="xe-perf-control -q"
+   echo $CMD
+   $CMD
+fi
+
 if [ "${USE_I915_PERF}" ]; then
     CMD="i915-perf-recorder -m ${I915_PERF_METRIC} -s 8000 -k ${CLOCK} -e ${I915_PERF_ENGINE_CLASS} -i ${I915_PERF_ENGINE_INSTANCE}"
+    echo $CMD
+    $CMD &
+fi
+
+if [ "${USE_XE_PERF}" ]; then
+    CMD="xe-perf-recorder -m ${XE_PERF_METRIC} -s 8000 -k ${CLOCK} -e ${XE_PERF_ENGINE_CLASS} -i ${XE_PERF_ENGINE_INSTANCE}"
     echo $CMD
     $CMD &
 fi

--- a/sample/trace-cmd-stop-tracing.sh
+++ b/sample/trace-cmd-stop-tracing.sh
@@ -14,5 +14,11 @@ if [ "${USE_I915_PERF} " ]; then
     $CMD
 fi
 
+if [ "${USE_XE_PERF} " ]; then
+    CMD="xe-perf-control -q"
+    echo $CMD
+    $CMD
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ${SCRIPT_DIR}/trace-cmd-status.sh

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -2619,7 +2619,10 @@ uint32_t TraceWin::graph_render_i915_perf_events( graph_info_t &gi )
 
                 gi.i915_perf_bars.push_back( event.id );
 
-                m_i915_perf.counters.set_event( event );
+                if ( m_trace_events.m_i915.is_xe )
+                    m_i915_perf.counters.set_event_xe( event );
+                else
+                    m_i915_perf.counters.set_event( event );
             }
         }
     }

--- a/src/gpuvis_graphrows.cpp
+++ b/src/gpuvis_graphrows.cpp
@@ -460,8 +460,16 @@ void GraphRows::init( TraceEvents &trace_events )
     {
         if ( !trace_events.m_i915.perf_locs.empty() )
         {
-            push_row( "i915-perf", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
-            push_row( "i915-perf-freq", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+            if ( trace_events.m_i915.is_xe )
+            {
+                push_row( "xe-perf", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+                push_row( "xe-perf-freq", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+            }
+            else
+            {
+                push_row( "i915-perf", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+                push_row( "i915-perf-freq", LOC_TYPE_i915Perf, trace_events.m_i915.perf_locs.size() );
+            }
         }
 
         for ( auto &req_locs : trace_events.m_i915.req_locs.m_locs.m_map )

--- a/src/i915-perf/i915-perf-read.h
+++ b/src/i915-perf/i915-perf-read.h
@@ -33,6 +33,8 @@
 extern "C" {
     struct intel_perf_data_reader;
     struct intel_perf_logical_counter;
+    struct intel_xe_perf_data_reader;
+    struct intel_xe_perf_logical_counter;
 }
 
 typedef std::function< void ( const trace_event_t &event, int64_t ts, float value ) > I915CounterCallback;
@@ -42,5 +44,11 @@ struct intel_perf_logical_counter *get_i915_perf_frequency_counter( struct intel
 void load_i915_perf_counter_values( struct intel_perf_data_reader *reader,
                                     struct intel_perf_logical_counter *counter,
                                     const trace_event_t &event, I915CounterCallback &cb );
+
+int read_xe_perf_file( const char *file, StrPool &strpool, trace_info_t &trace_info, struct intel_xe_perf_data_reader **out_reader, EventCallback &cb );
+struct intel_xe_perf_logical_counter *get_xe_perf_frequency_counter( struct intel_xe_perf_data_reader *reader );
+void load_xe_perf_counter_values( struct intel_xe_perf_data_reader *reader,
+				  struct intel_xe_perf_logical_counter *counter,
+				  const trace_event_t &event, I915CounterCallback &cb );
 
 #endif // I915_PERF_READ_H_


### PR DESCRIPTION
Add support for perf traces from the new Intel Xe driver. This requires linking with the new 'xe-oa' IGT library, similar to the previous 'i915-perf' library. Exported symbols from 'xe-oa' lib are in a different namespace from 'i915-perf' lib, allowing gpuvis to call into both libraries.

The traces from Xe driver are collected using 'xe-perf-recorder' tool (similar to 'i915-perf-recorder' tool). To start collection `export USE_XE_PERF=1`.

Overall, presentation of perf traces from Xe KMD in gpuvis is considered a subset of the i915 perf functionality. So Xe code paths in gpuvis reuse i915 code paths, except they call into the 'xe-oa' library rather than the 'i915-perf' library. So gpuvis is compiled with 'use_i915_perf' option as with i915-perf.

This pull request is based on the IGT library changes submitted here: 
    https://patchwork.freedesktop.org/series/130033/#rev2