### PR TITLE
Move va_start+va_end into string_format loop

### DIFF
--- a/src/gpuvis_macros.h
+++ b/src/gpuvis_macros.h
@@ -249,7 +249,6 @@ std::string get_realpath( const char *filename );
 bool copy_file( const char *filename, const char *newfilename );
 
 std::string string_format( const char *fmt, ... ) ATTRIBUTE_PRINTF( 1, 2 );
-std::string string_formatv( const char *fmt, va_list ap ) ATTRIBUTE_PRINTF( 1, 0 );
 
 std::string string_strftime();
 

--- a/src/gpuvis_utils.cpp
+++ b/src/gpuvis_utils.cpp
@@ -206,15 +206,18 @@ std::string ts_to_timestr( int64_t event_ts, int precision, const char *suffix )
     return string_format( "%.*lf%s", precision, val, suffix ? suffix : " ms" );
 }
 
-std::string string_formatv( const char *fmt, va_list ap )
+std::string string_format( const char *fmt, ... )
 {
+    va_list ap;
     std::string str;
     int size = 512;
 
     for ( ;; )
     {
         str.resize( size );
+        va_start( ap, fmt );
         int n = vsnprintf( ( char * )str.c_str(), size, fmt, ap );
+        va_end( ap );
 
         if ( ( n > -1 ) && ( n < size ) )
         {
@@ -224,16 +227,6 @@ std::string string_formatv( const char *fmt, va_list ap )
 
         size = ( n > -1 ) ? ( n + 1 ) : ( size * 2 );
     }
-}
-
-std::string string_format( const char *fmt, ... )
-{
-    va_list ap;
-    std::string str;
-
-    va_start( ap, fmt );
-    str = string_formatv( fmt, ap );
-    va_end( ap );
 
     return str;
 }


### PR DESCRIPTION
Calling `vsnprintf` more than once on the same `va_list` pointer doesn't work. After each iteration, `va_end`/`va_start` is needed to reinitialize the `va_list`.

`string_formatv` can't call `va_start`/`va_end` itself. It's only used by `string_format`, so we can move the loop to `string_format` and delete `string_formatv`.

This fixes a crash I encountered when I tried listing events with really long strings (>512 chars) as data.