### PR TITLE
Update trace-cmd-status.sh

### DIFF
--- a/sample/trace-cmd-status.sh
+++ b/sample/trace-cmd-status.sh
@@ -42,13 +42,13 @@ done
 
 awk 'BEGIN { time = 0; entries = 0; overrun = 0 }
     {
-       if ( $0 ~ /^entries\:/ )
+       if ( $0 ~ '/^entries\:/' )
            entries = $2
-       if ( $0 ~ /^overrun\:/ )
+       if ( $0 ~ '/^overrun\:/' )
            overrun = $2
-       if ( $0 ~ /^oldest event ts\:/ )
+       if ( $0 ~ '/^oldest\ event\ ts\:/' )
            time = (float)$4
-       if ( $0 ~ /^now ts\:/ ) {
+       if ( $0 ~ '/^now\ ts\:/' ) {
            time = (float)$3 - time
            if ( entries == 0 )
                printf "%s entries:%u\n", FILENAME, entries


### PR DESCRIPTION
Fixes #63 by altering string handling for awk regexp matches - wrap expressions in apostrophes and explicitly escape out spaces.

Tested against awk 5.3.0