### PR TITLE
Fix msm events handling

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -2145,11 +2145,23 @@ void TraceEvents::init_msm_timeline_event( trace_event_t &event )
 
     const std::vector< uint32_t > *plocs = m_gfxcontext_locs.get_locations_u64( gfxcontext_hash );
 
-    event.flags |= TRACE_FLAG_TIMELINE;
-
     if ( !strcmp( event.name, "msm_gpu_submit_retired" ) )
     {
-        event.flags |= TRACE_FLAG_FENCE_SIGNALED;
+        trace_event_t event0;
+
+        // Look for a matching flush event
+        for (int32_t i =  plocs->size() - 1; i >= 0; i--) {
+            event0 = m_events[ plocs->at(i) ];
+            if (!strcmp( event0.name, "msm_gpu_submit_flush" ) ) {
+                event.flags |= TRACE_FLAG_FENCE_SIGNALED;
+
+                for ( uint32_t idx : *plocs )
+                {
+                    m_events[ idx ].flags |= TRACE_FLAG_TIMELINE;
+                }
+                break;
+            }
+        }
     }
     else if ( !strcmp( event.name, "msm_gpu_submit_flush" ) )
     {

--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1677,6 +1677,8 @@ static void init_event_flags( trace_data_t &trace_data, trace_event_t &event )
         event.flags |= TRACE_FLAG_FENCE_SIGNALED;
     else if ( strstr( event.name, "amdgpu_cs_ioctl" ) )
         event.flags |= TRACE_FLAG_SW_QUEUE;
+    else if ( strstr( event.name, "msm_gpu_submit" ) )
+        event.flags |= TRACE_FLAG_SW_QUEUE;
     else if ( strstr( event.name, "amdgpu_sched_run_job" ) )
         event.flags |= TRACE_FLAG_HW_QUEUE;
 }


### PR DESCRIPTION
The code that handled msm events failed to set `id_start` and `user_comm` correctly which caused the wrong command name to appear in the timeline and sw and hw queue to incorrectly look identical.

Handle those similarly to how they are handled for AMD.