### PR TITLE
Remove code incorrectly flagging msm events

### DIFF
--- a/src/trace-cmd/trace-read.cpp
+++ b/src/trace-cmd/trace-read.cpp
@@ -1677,8 +1677,6 @@ static void init_event_flags( trace_data_t &trace_data, trace_event_t &event )
         event.flags |= TRACE_FLAG_FENCE_SIGNALED;
     else if ( strstr( event.name, "amdgpu_cs_ioctl" ) )
         event.flags |= TRACE_FLAG_SW_QUEUE;
-    else if ( strstr( event.name, "msm_gpu_submit" ) )
-        event.flags |= TRACE_FLAG_SW_QUEUE;
     else if ( strstr( event.name, "amdgpu_sched_run_job" ) )
         event.flags |= TRACE_FLAG_HW_QUEUE;
 }


### PR DESCRIPTION
All msm events that started with `msm_gpu_submit` where incorrectly being flagged as `TRACE_FLAG_SW_QUEUE`.

Remove this code since events are tagged anyway elsewhere.

This fixes the graph tooltip incorrectly reporting SW queue duration three times.