### PR TITLE
Add `gpuvis_print` event parsing

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -1010,7 +1010,7 @@ int SDLCALL MainApp::thread_func( void *data )
                 add_sched_switch_pid_comm( trace_events.m_trace_info, event, "prev_pid", "prev_comm" );
                 add_sched_switch_pid_comm( trace_events.m_trace_info, event, "next_pid", "next_comm" );
             }
-            else if ( event.is_ftrace_print() )
+            else if ( event.is_ftrace_print() || event.is_gpuvis_print() )
             {
                 trace_events.new_event_ftrace_print( event );
             }

--- a/src/trace-cmd/trace-read.h
+++ b/src/trace-cmd/trace-read.h
@@ -173,6 +173,7 @@ enum trace_flag_type_t {
     TRACE_FLAG_AUTOGEN_COLOR                = 0x20000,
     TRACE_FLAG_I915_PERF                    = 0x40000, // i915-perf gpu generated
     TRACE_FLAG_LINUX_PERF                   = 0x80000,
+    TRACE_FLAG_GPUVIS_PRINT                 = 0x100000, // Added for new `gpuvis_print` event type in kernel
 };
 
 struct trace_event_t
@@ -216,6 +217,7 @@ public:
 public:
     bool is_fence_signaled() const             { return !!( flags & TRACE_FLAG_FENCE_SIGNALED ); }
     bool is_ftrace_print() const               { return !!( flags & TRACE_FLAG_FTRACE_PRINT ); }
+    bool is_gpuvis_print() const               { return !!( flags & TRACE_FLAG_GPUVIS_PRINT ); }
     bool is_vblank() const                     { return !!( flags & TRACE_FLAG_VBLANK ); }
     bool is_timeline() const                   { return !!( flags & TRACE_FLAG_TIMELINE ); }
     bool is_sched_switch() const               { return !!( flags & TRACE_FLAG_SCHED_SWITCH ); }


### PR DESCRIPTION
This PR enables parsing of events that occur in the kernel, but wish to be parsed using the same style as the events that are generated from userspace (e.g. by writing to `/sys/kernel/tracing/trace_marker`).  Because they originate from the kernel, these events have the benefit of being able to use the `bprint` format which is significantly more efficient on-disk, as constant strings can be interned.  These events are currently being generated with a `system` of `gpuvis`, making them easy to distinguish from any other event in the trace record.

Ideally, we would more intelligently collect information from the more structured `bprint` format, however for now it's easier to re-use the parsing infrastructure used on `print` format entries.  Therefore, we manually synthesize a `buf` field by using `libtraceevent`'s convenient `tep_print_event()` function, then parse `gpuvis_print` events the same as the `ftrace_print` events already defined.

This PR was reviewed by @gaberowe.