### PR TITLE
Fix calculation of swapper process durations

### DIFF
--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -323,6 +323,7 @@ void Opts::init()
     init_opt_bool( OPT_ShowEventList, "Toggle showing event list", "show_event_list", true );
     init_opt_bool( OPT_SyncEventListToGraph, "Sync event list to graph mouse location", "sync_eventlist_to_graph", true );
     init_opt_bool( OPT_HideSchedSwitchEvents, "Hide sched_switch events", "hide_sched_switch_events", true );
+    init_opt_bool( OPT_HideIdleProcess, "Hide idle process", "hide_idle_process", true );
     init_opt_bool( OPT_ShowFps, "Show frame rate", "show_fps", false );
     init_opt_bool( OPT_VerticalSync, "Vertical sync", "vertical_sync", true );
 

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -1072,6 +1072,7 @@ enum : uint32_t
     OPT_ShowEventList,
     OPT_SyncEventListToGraph,
     OPT_HideSchedSwitchEvents,
+    OPT_HideIdleProcess,
     OPT_RenderCrtc0,
     OPT_RenderCrtc1,
     OPT_RenderCrtc2,

--- a/src/gpuvis_graph.cpp
+++ b/src/gpuvis_graph.cpp
@@ -1643,10 +1643,16 @@ uint32_t TraceWin::graph_render_cpus_timeline( graph_info_t &gi )
 
                 event_renderer.done();
 
-                imgui_drawrect_filled( x0, y + imgui_scale( 2.0f ), x1 - x0, row_h - imgui_scale( 3.0f ), sched_switch.color );
+                // The swapper / idle process regions are quite visually noisy, so optionally hide their bg and text
+                const bool visible_bg_and_text = !( sched_switch.pid == 0 && s_opts().getb( OPT_HideIdleProcess ) ); 
+
+                if ( visible_bg_and_text )
+                {
+                    imgui_drawrect_filled( x0, y + imgui_scale( 2.0f ), x1 - x0, row_h - imgui_scale( 3.0f ), sched_switch.color );
+                }
 
                 // If alt key isn't down and there is room for ~12 characters, render comm name
-                if ( !alt_down && ( x1 - x0 > text_size.x ) )
+                if ( visible_bg_and_text && !alt_down && ( x1 - x0 > text_size.x ) )
                 {
                     float y_text = y + ( row_h - text_size.y ) / 2 - imgui_scale( 1.0f );
                     const char *prev_comm = get_event_field_val( sched_switch, "prev_comm" );


### PR DESCRIPTION
The swapper process has pid 0 across all cores, but we always want to be looking for the previous event on the current core only. This corrects the duration and thus, visualization of the swapper process.

I'm not entirely sure whether the performance of a linear scan will be prohibitive here, this was just the dumbest fast solution, and also I think this change probably warrants some small UI tweaks to de-emphasize the swapper zones, since they look a bit noisy this way...

![image](https://github.com/user-attachments/assets/70608228-be94-46c4-93a5-ff9ed10f6fd6)

edit: Added a simple commit which skips the background and comm text for swapper regions. Not sure what other people's vibes are here, but I like it personally.

![image](https://github.com/user-attachments/assets/7985c0af-c8c7-49ff-9223-bfcaf3019ec1)
