### PR TITLE
intel/xe: Change xe-perf-recorder command line

### DIFF
--- a/sample/trace-cmd-setup.sh
+++ b/sample/trace-cmd-setup.sh
@@ -85,7 +85,7 @@ fi
 
 # Enable i915/xe perf to collect GPU data.
 ROOT_CMDS+="sysctl --ignore dev.i915.perf_stream_paranoid=0"
-ROOT_CMDS+="sysctl --ignore dev.xe.perf_stream_paranoid=0"
+ROOT_CMDS+="sysctl --ignore dev.xe.observation_paranoid=0"
 
 if [ -z "${ROOT_CMDS}" ]; then
     :

--- a/sample/trace-cmd-start-tracing.sh
+++ b/sample/trace-cmd-start-tracing.sh
@@ -35,14 +35,9 @@ if [ "${USE_XE_PERF}" ]; then
         XE_PERF_METRIC="RenderBasic"
     fi
 
-    if [ -z "${XE_PERF_ENGINE_CLASS}" ]; then
-        echo "WARNING: Missing XE_PERF_ENGINE_CLASS value. Using default value 0 (Render Class)."
-        XE_PERF_ENGINE_CLASS=0
-    fi
-
-    if [ -z "${XE_PERF_ENGINE_INSTANCE}" ]; then
-        echo "WARNING: Missing XE_PERF_ENGINE_INSTANCE value. Using default instance 0."
-        XE_PERF_ENGINE_INSTANCE=0
+    if [ -z "${XE_OA_UNIT_ID}" ]; then
+        echo "WARNING: Missing XE_OA_UNIT_ID value. Using default value 0."
+        XE_OA_UNIT_ID=0
     fi
 fi
 
@@ -123,7 +118,7 @@ if [ "${USE_I915_PERF}" ]; then
 fi
 
 if [ "${USE_XE_PERF}" ]; then
-    CMD="xe-perf-recorder -m ${XE_PERF_METRIC} -s 8000 -k ${CLOCK} -e ${XE_PERF_ENGINE_CLASS} -i ${XE_PERF_ENGINE_INSTANCE}"
+    CMD="xe-perf-recorder -m ${XE_PERF_METRIC} -s 8000 -k ${CLOCK} -u ${XE_OA_UNIT_ID}"
     echo $CMD
     $CMD &
 fi


### PR DESCRIPTION
xe-perf-recorder command line has been changed to use the OA unit id rather than engine class/instance to identify the OA unit for Xe OA data capture. Change gpuvis scripts to reflect that change.